### PR TITLE
fix: 마이페이지 아이콘 매핑 오류

### DIFF
--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -138,7 +138,7 @@ const MyPage = () => {
           <div className="relative">
             <div className="flex h-[275px] w-[275px] items-center justify-center overflow-hidden rounded-full border-[4px] border-brand-primary bg-gray-50">
               <Icon
-                name={gender === "FEMALE" ? "FEMALE" : "MALE"}
+                name={gender === "FEMALE" ? "female" : "male"}
                 className="h-full w-full object-cover"
               />
             </div>


### PR DESCRIPTION
## 📌 개요

- 파일 경로 수정되면서 성별 아이콘 매핑 오류 발생

---

## ✅ 작업 내용

- [x] 파일명 수정

---

## 📷 작업 결과
### 전
<img width="887" height="565" alt="image" src="https://github.com/user-attachments/assets/2dac6da7-19d7-4432-85b5-16b5d27af1c7" />

### 후
<img width="865" height="558" alt="image" src="https://github.com/user-attachments/assets/73dff053-e4e3-4d13-879a-53f6d2aa22fe" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
