### PR TITLE
feat: 증상 가이드 API 연동

### DIFF
--- a/src/components/Modal/components/home/components/DoctorOpinionContent.tsx
+++ b/src/components/Modal/components/home/components/DoctorOpinionContent.tsx
@@ -4,9 +4,14 @@ import type { OpinionDetail } from "@/pages/home/types/homeDoctorOpinion";
 import useDoctorOpinionModalStore from "@/stores/modal/useDoctorOpinionModalStore";
 import { useEffect, useState } from "react";
 import SharePost from "./SharePost";
+import { useAuthStore } from "@/stores/login/useAuthStore";
+import { useSymptomGuideStore } from "@/stores/symptom/useSymptomGuideStore";
 
 const DoctorOpinionContent = () => {
   const { doctorOpinionId, setDoctorOpinionId } = useDoctorOpinionModalStore();
+
+  const { painAreaID } = useAuthStore();
+  const { recordEvent } = useSymptomGuideStore();
 
   const [data, setData] = useState<OpinionDetail | null>(null);
   const [loading, setLoading] = useState(false);
@@ -24,6 +29,11 @@ const DoctorOpinionContent = () => {
         setLoading(true);
         const detail = await GetDoctorOpinionDetail({ answerId: doctorOpinionId });
         setData(detail);
+
+        // 트리거 해제
+        if (painAreaID) {
+          await recordEvent(painAreaID, "DOCTOR_OPINION_VIEWED");
+        }
       } catch {
         setData(null);
       } finally {
@@ -32,7 +42,7 @@ const DoctorOpinionContent = () => {
     };
 
     void run();
-  }, [doctorOpinionId]);
+  }, [doctorOpinionId, painAreaID, recordEvent]);
 
   const handleOpenSource = (url: string) => {
     if (!url) return;

--- a/src/components/Modal/components/home/components/TemporaryMeasureContent.tsx
+++ b/src/components/Modal/components/home/components/TemporaryMeasureContent.tsx
@@ -9,12 +9,17 @@ import useIsMobile from "@/hooks/useIsMobile";
 import type { TemporaryGuideDetail } from "@/types/temporaryGuide";
 import { getTemporaryGuideDetail } from "@/components/Modal/services/getTemporaryDetail";
 import SharePost from "./SharePost";
+import { useAuthStore } from "@/stores/login/useAuthStore";
+import { useSymptomGuideStore } from "@/stores/symptom/useSymptomGuideStore";
 
 const TemporaryMeasureContent = () => {
   const { id } = useParams();
   const isMobile = useIsMobile();
-  const { measureId, setMeasureId } = useTemporaryMeasureModalStore();
   const navigate = useNavigate();
+
+  const { measureId, setMeasureId } = useTemporaryMeasureModalStore();
+  const { painAreaID } = useAuthStore();
+  const { recordEvent } = useSymptomGuideStore();
 
   const guideId = useMemo(() => {
     const raw = measureId ?? id;
@@ -34,6 +39,11 @@ const TemporaryMeasureContent = () => {
       try {
         const res = await getTemporaryGuideDetail(guideId);
         setDetail(res.data ?? null);
+
+        // 트리거 해제
+        if (painAreaID) {
+          await recordEvent(painAreaID, "TREATMENT_INFO_VIEWED");
+        }
       } catch (e) {
         console.error("[TemporaryGuideDetail] error:", e);
         setDetail(null);
@@ -41,7 +51,7 @@ const TemporaryMeasureContent = () => {
     };
 
     run();
-  }, [guideId]);
+  }, [guideId, painAreaID, recordEvent]);
 
   const handleSelectMorePost = (answerId: number) => {
     if (isMobile) {
@@ -49,7 +59,6 @@ const TemporaryMeasureContent = () => {
       return;
     }
 
-    // 데스크탑(모달)에서는 모달 내용만 교체
     setMeasureId(String(answerId));
   };
 

--- a/src/components/Modal/components/symptom/StepDoctorOpinionRequiredModal.tsx
+++ b/src/components/Modal/components/symptom/StepDoctorOpinionRequiredModal.tsx
@@ -1,15 +1,31 @@
 import Icon from "@/components/Icon/Icon";
 import useBaseModal from "@/stores/modal/useBaseModal";
 import { useNavigate } from "react-router-dom";
-import { ModalType } from "../../types/modal";
+import { useHomeStore } from "@/stores/home/useHomeStore";
+import useDoctorOpinionModalStore from "@/stores/modal/useDoctorOpinionModalStore";
+import { ModalType } from "@/components/Modal/types/modal";
 
 // 전문의 답변 미확인 모달 (2 → 3단계)
 const StepDoctorOpinionRequiredModal = () => {
   const navigate = useNavigate();
   const { openModal, closeModal } = useBaseModal();
 
+  const { symptoms } = useHomeStore();
+  const { setDoctorOpinionId } = useDoctorOpinionModalStore();
+
   // 전문의 답변 상세 보기 모달 조회
   const handleOpenDoctorOpinion = () => {
+    const targetSymptom = symptoms[0];
+    const answerId = targetSymptom?.answerId;
+
+    if (!answerId) {
+      alert("전문의 답변 정보를 찾을 수 없습니다.");
+      return;
+    }
+
+    // 상세 모달에 필요한 ID 설정
+    setDoctorOpinionId(answerId);
+
     navigate("/home");
     openModal(ModalType.HOME_DOCTOR_OPINION);
   };

--- a/src/components/Modal/components/symptom/StepTreatmentInfoRequiredModal.tsx
+++ b/src/components/Modal/components/symptom/StepTreatmentInfoRequiredModal.tsx
@@ -1,15 +1,31 @@
 import Icon from "@/components/Icon/Icon";
 import useBaseModal from "@/stores/modal/useBaseModal";
+import { ModalType } from "../../types/modal";
+import { useHomeStore } from "@/stores/home/useHomeStore";
+import useTemporaryMeasureModalStore from "@/stores/modal/useTemporaryMeasureModalStore";
 import { useNavigate } from "react-router-dom";
 
 // 대처 방법 / 병원 정보 미확인 모달 (3 → 4단계)
 const StepTreatmentInfoRequiredModal = () => {
   const navigate = useNavigate();
-  const { closeModal } = useBaseModal();
+  const { openModal, closeModal } = useBaseModal();
 
-  // 홈으로 이동
-  const handleGoHome = () => {
+  const { temporaryGuides } = useHomeStore();
+  const { setMeasureId } = useTemporaryMeasureModalStore();
+
+  const goToTreatmentInfo = () => {
+    // 리스트의 첫 번째 아이템의 guideId 확인
+    const firstGuideId = temporaryGuides[0]?.guideId;
+
+    if (!firstGuideId) {
+      alert("데이터를 불러오는 중입니다. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+
+    // 상세 페이지에 보여줄 ID 설정
+    setMeasureId(String(firstGuideId));
     navigate("/home");
+    openModal(ModalType.HOME_TEMPORARY_MEASURE);
   };
 
   return (
@@ -33,7 +49,6 @@ const StepTreatmentInfoRequiredModal = () => {
           </div>
         </div>
 
-        {/* Buttons */}
         <div className="flex gap-2">
           <button
             type="button"
@@ -44,7 +59,7 @@ const StepTreatmentInfoRequiredModal = () => {
           </button>
           <button
             type="button"
-            onClick={handleGoHome}
+            onClick={goToTreatmentInfo}
             className="inline-flex h-12 w-full items-center justify-center rounded-[4px] bg-brand-primary text-center text-base font-semibold leading-none text-white transition-colors hover:opacity-90 sm:text-lg"
           >
             대처·병원 확인하기

--- a/src/pages/symptom/services/getSymptomGuide.ts
+++ b/src/pages/symptom/services/getSymptomGuide.ts
@@ -1,0 +1,32 @@
+import { authApiWrapper } from "@/utils/api/api";
+
+// 각 단계에 대한 타입
+export interface StepData {
+  step: number;
+  title: string;
+  subtitle: string;
+  caption: string;
+  description: string;
+  imageUrl: string;
+}
+
+// 사용자의 현재 진행 상태에 대한 타입
+export interface UserProgress {
+  currentStep: number;
+  lastVisitedAt: string; // ISO 8601
+}
+
+export interface SymptomGuideData {
+  painAreaId: number;
+  steps: StepData[];
+  userProgress: UserProgress | null; // 첫 방문 시 null
+}
+
+// 증상별 가이드 4단계 전체 조회
+const getSymptomGuide = async (painAreaId: string | number): Promise<SymptomGuideData> => {
+  const res = await authApiWrapper.get<SymptomGuideData>(`/symptoms/${painAreaId}/guide`);
+
+  return res.data;
+};
+
+export default getSymptomGuide;

--- a/src/pages/symptom/services/postGuideStepEvent.ts
+++ b/src/pages/symptom/services/postGuideStepEvent.ts
@@ -1,0 +1,27 @@
+import { authApiWrapper } from "@/utils/api/api";
+
+export type GuideEventType = "DOCTOR_OPINION_VIEWED" | "TREATMENT_INFO_VIEWED";
+
+export interface GuideEventRequest {
+  event: GuideEventType;
+}
+
+export interface GuideEventData {
+  painAreaId: number;
+  event: GuideEventType;
+  recordedAt: string; // ISO 8601
+}
+
+// 사용자 행동 이벤트 기록 (트리거 해제용)
+const postGuideStepEvent = async (
+  painAreaId: string | number,
+  event: GuideEventType
+): Promise<GuideEventData> => {
+  const res = await authApiWrapper.post<GuideEventData>(`/symptoms/${painAreaId}/guide/events`, {
+    event,
+  });
+
+  return res.data;
+};
+
+export default postGuideStepEvent;

--- a/src/pages/symptom/services/postGuideStepReset.ts
+++ b/src/pages/symptom/services/postGuideStepReset.ts
@@ -1,0 +1,18 @@
+import { authApiWrapper } from "@/utils/api/api";
+
+export interface GuideResetData {
+  painAreaId: number;
+  progress: {
+    currentStep: number;
+    resetAt: string; // ISO 8601
+  };
+}
+
+// 증상 가이드 초기화
+const postGuideStepReset = async (painAreaId: string | number): Promise<GuideResetData> => {
+  const res = await authApiWrapper.post<GuideResetData>(`/symptoms/${painAreaId}/guide/reset`);
+
+  return res.data;
+};
+
+export default postGuideStepReset;

--- a/src/pages/symptom/services/postGuideStepValidate.ts
+++ b/src/pages/symptom/services/postGuideStepValidate.ts
@@ -1,0 +1,25 @@
+import { authApiWrapper } from "@/utils/api/api";
+
+export interface GuideValidateRequest {
+  fromStep: number;
+  toStep: number;
+}
+
+export interface GuideValidateData {
+  canMove: boolean;
+}
+
+// 단계 전환 가능 여부 검증 (트리거 관리)
+const postGuideStepValidate = async (
+  painAreaId: string | number,
+  steps: GuideValidateRequest
+): Promise<GuideValidateData> => {
+  const res = await authApiWrapper.post<GuideValidateData>(
+    `/symptoms/${painAreaId}/guide/validate`,
+    steps
+  );
+
+  return res.data;
+};
+
+export default postGuideStepValidate;

--- a/src/pages/symptom/tabs/symptom-guide/SymptomGuideTab.tsx
+++ b/src/pages/symptom/tabs/symptom-guide/SymptomGuideTab.tsx
@@ -1,5 +1,5 @@
 import confetti from "canvas-confetti";
-import { useMemo, useState, useRef } from "react";
+import { useMemo, useRef, useEffect } from "react";
 import SectionTitle from "@/pages/symptom/components/common/SectionTitle";
 import StepCardList from "@/pages/symptom/tabs/symptom-guide/components/StepCardList";
 import StepDescription from "@/pages/symptom/tabs/symptom-guide/components/StepDescription";
@@ -7,6 +7,8 @@ import Button from "@/components/Button/Button";
 import useBaseModal from "@/stores/modal/useBaseModal";
 import { ModalType } from "@/components/Modal/types/modal";
 import useIsMobile from "@/hooks/useIsMobile";
+import { useAuthStore } from "@/stores/login/useAuthStore";
+import { useSymptomGuideStore } from "@/stores/symptom/useSymptomGuideStore";
 
 export interface SymptomGuideStep {
   step: number;
@@ -34,8 +36,19 @@ const LIST_FIXED_H = 483 + 14;
 const COMPLETED_CENTER_INDEX = 1;
 
 const SymptomGuideTab = ({ symptomName }: SymptomGuideTabProps) => {
-  const { openModal } = useBaseModal(); // 모달 다시 쓸 거면 유지, 아니면 지워도 됨
   const isMobile = useIsMobile();
+
+  const { painAreaID } = useAuthStore();
+  const { openModal } = useBaseModal();
+  const { steps, currentIndex, completed, loading, fetchGuide, moveToNextStep, resetGuide } =
+    useSymptomGuideStore();
+
+  // 초기 데이터 패칭
+  useEffect(() => {
+    if (painAreaID) {
+      fetchGuide(painAreaID);
+    }
+  }, [painAreaID, fetchGuide]);
 
   // 완료 시 컨페티 효과
   const didFireConfettiRef = useRef(false);
@@ -48,72 +61,36 @@ const SymptomGuideTab = ({ symptomName }: SymptomGuideTabProps) => {
     });
   };
 
-  const steps: SymptomGuideStep[] = useMemo(
-    () => [
-      {
-        step: 1,
-        title: "불편함을 느낌",
-        subtitle: "어깨 통증을 인식함",
-        caption: "이 단계는 어깨에 불편함이나 통증이 있다는 것을 스스로 인식하는 단계예요.",
-        description:
-          "이 단계는 어깨에 불편함이나 통증이 있다는 것을 스스로 인식하는 단계예요. 많은 사람들이 이 시점에서 왜 이런 증상이 생겼는지 궁금해해요.",
-      },
-      {
-        step: 2,
-        title: "정보를 찾는 단계",
-        subtitle: "증상 원인을 이해함",
-        caption: "증상을 이해하는 것이 불안을 줄이는 데 도움이 될 수 있어요.",
-        description:
-          "이 단계에서는 어깨 통증이 어떤 이유로 생길 수 있는지 전문의 설명을 통해 알아볼 수 있어요. 증상을 이해하는 것이 불안을 줄이는 데 도움이 될 수 있어요.",
-      },
-      {
-        step: 3,
-        title: "대처 방법 참고하는 단계",
-        subtitle: "생활 관리/병원 고려",
-        caption: "일상에서 참고할 수 있는 관리 방법이나,병원 방문을 고려해볼 수 있어요.",
-        description:
-          "이 단계에서는 일상에서 참고할 수 있는 관리 방법이나, 병원 방문을 고려할 수 있어요.",
-      },
-      {
-        step: 4,
-        title: "상태를 안정적으로 인지",
-        subtitle: "증상 변화를 스스로 느끼고 판단",
-        caption: "증상에 대해 알고 있어\n이전보다 덜 불안하게 느껴질 수 있어요.",
-        description:
-          "증상에 대해 알고 있어 이전보다 덜 불안하게 느껴질 수 있어요. 현재 상태를 지켜보면서, 필요한 경우 병원을 고려할 수 있어요.",
-      },
-    ],
-    []
-  );
-
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [completed, setCompleted] = useState(false);
-
   // 현재 step은 "버튼 흐름" 기준
   const currentStep = steps[currentIndex];
 
   const buttonText = useMemo(() => {
     if (completed) return "초기화";
+
+    if (currentIndex === steps.length - 1) return `${symptomName} 가이드 확인 완료`;
     if (currentIndex === 0) return "이 증상에 대해 알아보고 싶어요";
     if (currentIndex === 1) return "이 증상에 대한 설명을 이해했어요";
-    if (currentIndex === 2) return "대응 방법을 확인했어";
-    return "어깨 증상 가이드 확인 완료";
-  }, [completed, currentIndex]);
+    if (currentIndex === 2) return "대응 방법을 확인했어요";
 
-  const onClickButton = () => {
+    return `${symptomName} 가이드 확인 완료`;
+  }, [completed, currentIndex, steps.length]);
+
+  const onClickButton = async () => {
+    if (!painAreaID) return;
+
     if (completed) {
-      setCompleted(false);
-      setCurrentIndex(0);
-
-      didFireConfettiRef.current = false;
+      if (confirm("가이드 진행 상황을 초기화하시겠습니까?")) {
+        await resetGuide(painAreaID);
+        await fetchGuide(painAreaID);
+        didFireConfettiRef.current = false;
+      }
       return;
     }
 
-    // step4에서 누르면 완료 상태로 전환
+    // 마지막 단계
     if (currentIndex === steps.length - 1) {
-      setCompleted(true);
+      useSymptomGuideStore.setState({ completed: true });
 
-      // 컨페티 효과(1회)
       if (!didFireConfettiRef.current) {
         didFireConfettiRef.current = true;
         fireConfetti();
@@ -121,27 +98,29 @@ const SymptomGuideTab = ({ symptomName }: SymptomGuideTabProps) => {
       return;
     }
 
-    // 2단계 -> 3단계: 전문의 소견 모달
-    if (currentIndex === 1) {
-      openModal(ModalType.STEP_DOCTOR_OPINION_REQUIRED);
-      return;
-    }
-    // 3단계 -> 4단계: 대처방안/병원 모달
-    if (currentIndex === 2) {
-      openModal(ModalType.STEP_TREATMENT_INFO_REQUIRED);
-      return;
-    }
+    // 일반 단계 이동 (Step 1~3)
+    const canMove = await moveToNextStep(painAreaID);
 
-    setCurrentIndex((prev) => Math.min(prev + 1, steps.length - 1));
+    // 이동 실패 시 (모달/페이지 트리거)
+    if (!canMove) {
+      if (currentIndex === 1) {
+        openModal(ModalType.STEP_DOCTOR_OPINION_REQUIRED);
+      } else if (currentIndex === 2) {
+        openModal(ModalType.STEP_TREATMENT_INFO_REQUIRED);
+      }
+      return;
+    }
   };
 
-  // 카드 표시용 index (완료 시 2단계를 중앙)
+  // 데이터 로딩 중 방어 코드
+  if (loading || steps.length === 0) return null;
+
   const displayIndex = completed ? COMPLETED_CENTER_INDEX : currentIndex;
 
   // 말풍선 내용
   const bubbleStep = completed ? "확인 완료" : `Step ${currentStep.step}`;
   const bubbleDescription = completed
-    ? "어깨 증상에 대한 확인할 수 있는 가이드를 모두 살펴봤어요.\n현재 상태를 지켜보며 필요하면 의료진 상담을 고려해 주세요."
+    ? `${symptomName} 증상에 대한 확인할 수 있는 가이드를 모두 살펴봤어요.\n현재 상태를 지켜보며 필요하면 의료진 상담을 고려해 주세요.`
     : currentStep.description;
 
   // 데스크탑 말풍선 위치/꼬리 방향
@@ -182,7 +161,7 @@ const SymptomGuideTab = ({ symptomName }: SymptomGuideTabProps) => {
 
       {/* 말풍선 */}
       <div
-        className="relative w-full max-w-[1020px] overflow-visible"
+        className="relative w-[80%] max-w-[1020px] overflow-visible md:w-full"
         style={{ height: BUBBLE_H + 18 }}
       >
         <StepDescription
@@ -196,12 +175,12 @@ const SymptomGuideTab = ({ symptomName }: SymptomGuideTabProps) => {
       </div>
 
       {/* 버튼 */}
-      <div className="mt-8 flex w-full max-w-[1020px] justify-center pb-[40px]">
+      <div className="mt-8 flex w-full max-w-[1020px] justify-center px-[30px] pb-[40px]">
         <Button
           type="button"
           fullWidth={false}
           onClick={onClickButton}
-          className="h-[48px] w-[404px] rounded-[4px] px-[10px] text-[18px] font-medium leading-[140%] tracking-[-0.025em]"
+          className="h-[48px] w-full rounded-[4px] text-[18px] font-medium leading-[140%] tracking-[-0.025em] md:w-[404px]"
         >
           {buttonText}
         </Button>

--- a/src/pages/symptom/tabs/symptom-guide/components/StepCardList.tsx
+++ b/src/pages/symptom/tabs/symptom-guide/components/StepCardList.tsx
@@ -1,4 +1,3 @@
-// StepCardList.tsx
 import StepCard from "./StepCard";
 import type { SymptomGuideStep } from "@/pages/symptom/tabs/symptom-guide/SymptomGuideTab";
 import img1 from "/images/test/symptom_test1.png";

--- a/src/stores/symptom/useSymptomGuideStore.ts
+++ b/src/stores/symptom/useSymptomGuideStore.ts
@@ -1,0 +1,88 @@
+import type { StepData, SymptomGuideData } from "@/pages/symptom/services/getSymptomGuide";
+import getSymptomGuide from "@/pages/symptom/services/getSymptomGuide";
+import type { GuideEventType } from "@/pages/symptom/services/postGuideStepEvent";
+import postGuideStepEvent from "@/pages/symptom/services/postGuideStepEvent";
+import postGuideStepReset from "@/pages/symptom/services/postGuideStepReset";
+import postGuideStepValidate from "@/pages/symptom/services/postGuideStepValidate";
+import { create } from "zustand";
+
+interface SymptomGuideState {
+  steps: StepData[];
+  currentIndex: number;
+  completed: boolean;
+  loading: boolean;
+
+  fetchGuide: (painAreaId: number | string) => Promise<void>;
+  recordEvent: (painAreaId: number | string, event: GuideEventType) => Promise<boolean>;
+  moveToNextStep: (painAreaId: number | string) => Promise<boolean>;
+  resetGuide: (painAreaId: number | string) => Promise<void>;
+  setIndex: (index: number) => void;
+}
+
+export const useSymptomGuideStore = create<SymptomGuideState>((set, get) => ({
+  steps: [],
+  currentIndex: 0,
+  completed: false,
+  loading: false,
+
+  fetchGuide: async (painAreaId) => {
+    set({ loading: true });
+    try {
+      const data: SymptomGuideData = await getSymptomGuide(painAreaId);
+      const userStep = data.userProgress?.currentStep || 1;
+      set({
+        steps: data.steps,
+        currentIndex: userStep > 4 ? 3 : userStep - 1,
+        completed: userStep > 4,
+      });
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  // 트리거 해제용
+  recordEvent: async (painAreaId, event) => {
+    try {
+      await postGuideStepEvent(painAreaId, event);
+      return true; // 기록 성공 시 true 반환
+    } catch (error) {
+      console.error("이벤트 기록 실패:", error);
+      return false;
+    }
+  },
+
+  moveToNextStep: async (painAreaId) => {
+    const { currentIndex, steps } = get();
+    const fromStep = currentIndex + 1;
+    const toStep = fromStep + 1;
+
+    try {
+      // 다음 단계 이동 가능 여부 체크
+      const { canMove } = await postGuideStepValidate(painAreaId, { fromStep, toStep });
+
+      if (canMove) {
+        if (currentIndex === steps.length - 1) {
+          set({ completed: true });
+        } else {
+          set({ currentIndex: currentIndex + 1 });
+        }
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error("Step 이동 실패", error);
+      return false;
+    }
+  },
+
+  resetGuide: async (painAreaId) => {
+    try {
+      await postGuideStepReset(painAreaId);
+      set({ currentIndex: 0, completed: false });
+    } catch (error) {
+      console.error("초기화 실패", error);
+    }
+  },
+
+  setIndex: (index) => set({ currentIndex: index }),
+}));


### PR DESCRIPTION
## 📌 개요

- 증상별 가이드 콘텐츠 전체 조회(4단계 전체)
- 단계 전환 가능 여부 검증 (트리거 관리): 단계 넘어갈 때 트리거 해제 여부 체크
  - 트리거 미해제 시 트리거 모달 띄움 
- 사용자 행동 이벤트 기록 (트리거 해제용)
  - 전문의소견 모달 / 임시대처방안 모달 열람시 트리거 해제 
- 진행 상태 초기화  

---

## ✅ 작업 내용

- [x] 증상별 가이드 콘텐츠 전체 조회(4단계 전체)
- [x] 단계 전환 가능 여부 검증 (트리거 관리)
- [x] 사용자 행동 이벤트 기록 (트리거 해제용)
- [x] 진행 상태 초기화  

---

## 📷 작업 결과

![화면 기록 2026-02-09 20 10 19](https://github.com/user-attachments/assets/aba27fd2-1717-4575-b48e-473c30b19cf1)

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [x] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
