### PR TITLE
fix: 회원가입 증상 선택 경고 문구 스크롤 고정 문제 수정

### DIFF
--- a/src/pages/signup/components/SignUpSymptomForm.tsx
+++ b/src/pages/signup/components/SignUpSymptomForm.tsx
@@ -121,9 +121,9 @@ const SignUpSymptomForm = () => {
   };
 
   return (
-    <>
+    <div className="relative">
       {errorConfig && (
-        <div className="fixed left-1/2 top-[330px] z-50 -translate-x-1/2 md:top-[287px]">
+        <div className="-mt-[78px] mb-8 flex justify-center md:-mt-[60px]">
           <div
             className={[
               errorConfig.widthClass,
@@ -166,7 +166,7 @@ const SignUpSymptomForm = () => {
           계속하기
         </Button>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📌 개요

- 회원가입 시 증상 중복 선택 경고 문구의 스크롤 고정 문제 수정
---

## ✅ 작업 내용

- [X] 회원가입 증상 선택 경고 문구 스크롤 고정 문제 수정

---

## 📷 작업 결과

---

## 🧪 테스트 여부

- [X] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [X] 리뷰어를 할당 했나요?
- [X] 작업자 할당 했나요?
- [ ] 라벨을 추가 했나요?
- [ ] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
