### PR TITLE
fix: 증상을 선택 후 홈에 들리지 않고 증상 가이드 전문의 답변 보기 클릭 시 오류

### DIFF
--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -12,6 +12,7 @@ import { parseBirthYMD } from "@/utils/formatBirth";
 import putUserMe from "@/pages/mypage/services/putUserMe";
 import { UNSELECTED_PAIN_AREA_ID, usePainAreas } from "@/hooks/usePainAreas";
 import putMyPainArea from "@/pages/mypage/services/putMyPainArea";
+import { useHomeStore } from "@/stores/home/useHomeStore";
 
 const MyPage = () => {
   const navigate = useNavigate();
@@ -31,10 +32,15 @@ const MyPage = () => {
     setPainAreaID,
     fetchMe,
   } = useAuthStore();
+  const { fetchHome } = useHomeStore();
 
   useEffect(() => {
     void fetchMe();
   }, [fetchMe]);
+
+  useEffect(() => {
+    fetchHome();
+  }, [storePainAreaID]);
 
   // painAreaID -> selectedKey(SYMPTOMS.key) 매칭
   const storeSelectedKey = useMemo(() => {


### PR DESCRIPTION
## 📌 개요

- 회원가입 시 증상 미선택으로 가입
- 마이페이지 > 증상 선택 > 증상 페이지의 증상가이드 탭
- 전문의 답변 확인 모달 > 전문의 답변보기 클릭 > 오류발생

---

## ✅ 작업 내용

- [x] 마이페이지에서 증상 최초 선택 시, home 내용 fetch하도록 수정

---

## 📷 작업 결과
![화면 기록 2026-02-11 15 05 19 (1)](https://github.com/user-attachments/assets/146ea58a-b71a-4418-aa03-fb43385f278b)

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [x] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
