### PR TITLE
fix: 비밀번호 재설정 인풋 수정

### DIFF
--- a/src/pages/password/components/PasswordResetForm.tsx
+++ b/src/pages/password/components/PasswordResetForm.tsx
@@ -1,11 +1,11 @@
 import Button from "@/components/Button/Button";
 import Icon from "@/components/Icon/Icon";
-import Input from "@/components/Input/Input";
 import { ModalType } from "@/components/Modal/types/modal";
 import { useBaseModal } from "@/stores/modal/useBaseModal";
 import { useMemo, useState } from "react";
 import postResetPassword from "@/pages/password/services/postResetPassword";
 import { useSearchParams } from "react-router-dom";
+import InputField from "@/components/Input/InputField";
 
 // 새 비밀번호 형식 검증: 미입력 / 8자 미만
 const validateNewPassword = (password: string) => {
@@ -100,7 +100,7 @@ const PasswordResetForm = () => {
               </span>
             </label>
 
-            <Input
+            <InputField
               id="reset-new-password"
               type="password"
               placeholder="새 비밀번호를 입력해주세요 (8자 이상)"
@@ -108,6 +108,9 @@ const PasswordResetForm = () => {
               onChange={(e) => setNewPassword(e.target.value)}
               onBlur={() => setTouchedPassword("newPassword")}
               hasError={!!newPasswordError}
+              clearable
+              passwordToggle
+              onClear={() => setNewPassword("")}
             />
 
             {newPasswordError ? (
@@ -129,7 +132,7 @@ const PasswordResetForm = () => {
               </span>
             </label>
 
-            <Input
+            <InputField
               id="reset-confirm-password"
               type="password"
               placeholder="새 비밀번호를 다시 입력하세요"
@@ -137,6 +140,9 @@ const PasswordResetForm = () => {
               onChange={(e) => setConfirmNewPassword(e.target.value)}
               onBlur={() => setTouchedPassword("confirmNewPassword")}
               hasError={!!confirmNewPasswordError}
+              clearable
+              passwordToggle
+              onClear={() => setConfirmNewPassword("")}
             />
 
             {confirmNewPasswordError ? (


### PR DESCRIPTION
## 📌 개요

- 비밀번호 재설정 인풋 수정

---

## ✅ 작업 내용

- [X] 전체 삭제 버튼 추가
- [X] 비밀번호 표시/숨김(눈 토글) 추가
---

## 📷 작업 결과
<img width="528" height="248" alt="image" src="https://github.com/user-attachments/assets/bdd23706-5c4e-4eaf-91af-24938aafdfc9" />

---

## 🧪 테스트 여부

- [X] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [X] 리뷰어를 할당 했나요?
- [X] 작업자 할당 했나요?
- [ ] 라벨을 추가 했나요?
- [X] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
