### PR TITLE
fix: 회원가입 시 탈퇴 계정 재가입 불가 메시지 처리

### DIFF
--- a/src/stores/signup/useSignupStore.ts
+++ b/src/stores/signup/useSignupStore.ts
@@ -70,7 +70,13 @@ export const useSignupStore = create<SignupState>((set) => ({
         const status = axiosError.response?.status;
         const code = axiosError.response?.data?.code;
 
-        if (status === 409 || code === "EMAIL_ALREADY_EXISTS") {
+        if (code === "ACCOUNT_RECENTLY_DELETED") {
+          set({
+            fieldErrors: {
+              email: "탈퇴 후 3일간 재가입이 불가능합니다.",
+            },
+          });
+        } else if (status === 409 || code === "EMAIL_ALREADY_EXISTS") {
           set({ fieldErrors: { email: "이미 가입된 이메일 주소입니다." } });
         } else if (status === 400) {
           switch (code) {


### PR DESCRIPTION
## 📌 개요

- 회원가입 ACCOUNT_RECENTLY_DELETED 에러 메시지 분기 처리

---

## ✅ 작업 내용

- [X] 회원가입 시 탈퇴 계정 재가입 불가 메시지 처리

---

## 📷 작업 결과
<img width="1919" height="946" alt="스크린샷 2026-02-11 214718" src="https://github.com/user-attachments/assets/65dfb6a9-a5e2-4366-b400-f29b26be7fbf" />

---

## 🧪 테스트 여부

- [X] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [X] 리뷰어를 할당 했나요?
- [X] 작업자 할당 했나요?
- [X] 라벨을 추가 했나요?
- [X] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
