### PR TITLE
fix: 미가입 이메일 비밀번호 재설정 에러 문구 및 토스트 처리

### DIFF
--- a/src/stores/password/useForgotPasswordStore.ts
+++ b/src/stores/password/useForgotPasswordStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 import postForgotPassword from "@/pages/password/services/postForgotPassword";
+import axios from "axios";
+import toast from "react-hot-toast";
 
 type ForgotPasswordState = {
   email: string;
@@ -27,11 +29,15 @@ export const useForgotPasswordStore = create<ForgotPasswordState>((set, get) => 
     }
 
     set({ loading: true, error: null });
+
     try {
       await postForgotPassword(email);
       return true;
-    } catch {
-      set({ error: "메일 발송에 실패했어요." });
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        toast.error("가입되지 않은 이메일입니다.");
+      }
+      set({ error: "가입되지 않은 이메일입니다." });
       return false;
     } finally {
       set({ loading: false });


### PR DESCRIPTION
## 📌 개요

- 미가입 이메일 비밀번호 재설정 에러 문구 및 토스트 처리

---

## ✅ 작업 내용

- [X] 미가입 이메일 비밀번호 재설정 에러 문구 수정
- [X] 실패 응답 시 toast.error(message)로 서버 응답 message를 토스트로 노출

---

## 📷 작업 결과
<img width="1919" height="885" alt="스크린샷 2026-02-11 220514" src="https://github.com/user-attachments/assets/45d61c94-4409-4bed-8fb7-43ea46d80508" />

---

## 🧪 테스트 여부

- [X] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [x] 리뷰어를 할당 했나요?
- [X] 작업자 할당 했나요?
- [X] 라벨을 추가 했나요?
- [X] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
