### PR TITLE
fix: 배너 타이틀 깨짐 수정

### DIFF
--- a/src/pages/home/components/banner/HomeBanner.tsx
+++ b/src/pages/home/components/banner/HomeBanner.tsx
@@ -73,7 +73,10 @@ const HomeBanner = () => {
       <div className="pointer-events-none relative inset-0 z-10">
         <div className="absolute bottom-10 left-0 ml-[30px] md:ml-[90px]">
           <div className="mb-5 flex h-[70px] w-[70px] items-center justify-center">
-            <Icon name={iconName} className="h-full w-full rounded-[10px] object-cover" />
+            <Icon
+              name={iconName}
+              className="h-full w-full rounded-[10px] object-cover shadow-[1px_2px_4px_0px_rgba(0,0,0,0.25)]"
+            />
           </div>
 
           <div className="mb-[70px] flex flex-col pr-[30px] text-xl font-bold leading-snug text-white md:mb-[151px] md:pr-[60px] md:text-[36px] md:leading-normal">


### PR DESCRIPTION
## 📌 개요

- 배너 타이틀 깨짐 (데스크탑 / 모바일)

---

## ✅ 작업 내용

- [x] 데스크탑 줄간격 조정
- [x] 모바일 줄바꿈 없이 출력
- [x] 모바일 텍스트 영역 조정

---

## 📷 작업 결과

<img width="3600" height="1162" alt="image" src="https://github.com/user-attachments/assets/9f8543b9-4f28-44ad-8908-748ce5d0d69b" />
<img width="1800" height="578" alt="image" src="https://github.com/user-attachments/assets/c13d4b87-c6fd-4ab8-97ee-206116656c59" />
<img width="1799" height="578" alt="image" src="https://github.com/user-attachments/assets/c360c437-68cf-4986-a228-96c421da5f34" />
<img width="1800" height="578" alt="image" src="https://github.com/user-attachments/assets/008f680d-71ca-4519-8bb4-3e1c9c6ab9b5" />
<img width="1800" height="581" alt="image" src="https://github.com/user-attachments/assets/76c90d9b-bd07-4354-9119-4c50d521c027" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/c4e523f4-76f6-4e50-94fd-b8fe73d63a2c" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f1da0226-984e-43ca-9e31-0534b68cef41" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d12cae08-7218-44a0-b23e-380b7d8c0fc1" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ed022a2c-7c1f-4d42-99cf-2bd4241f7094" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/88e3072d-0714-4d94-af2f-2066a4515a96" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ce02f455-811f-4c73-83e8-07c5354d6b11" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
