### PR TITLE
style: 위치 권한 거부 시 안내 문구 수정

### DIFF
--- a/src/pages/home/components/sections/map/fragments/HospitalMapSection.tsx
+++ b/src/pages/home/components/sections/map/fragments/HospitalMapSection.tsx
@@ -88,9 +88,11 @@ const HospitalMapSection = () => {
 
     const applyErr = (err: GeolocationPositionError) => {
       if (err.code === 1) {
-        isMobile
-          ? setLocationError("위치 권한이 거부되었습니다. 앱 설정에서 허용해 주세요.")
-          : setLocationError("위치 권한이 거부되었습니다. 브라우저 설정에서 허용해 주세요.");
+        if (isMobile) {
+          setLocationError("위치 권한이 거부되었습니다. 앱 설정에서 허용해 주세요.");
+        } else {
+          setLocationError("위치 권한이 거부되었습니다. 브라우저 설정에서 허용해 주세요.");
+        }
       } else if (err.code === 2) {
         setLocationError("위치 정보를 가져올 수 없습니다. 네트워크를 확인해 주세요.");
       } else if (err.code === 3) {


### PR DESCRIPTION
## 📌 개요

- 사용자 편의를 위해 위치 정보 거절 시 뜨는 "위치 정보 수집이 거절되었습니다" 문구가 사용자에게 혼란을 줄 수 있다고 파악됨
모바일: 앱 설정 / 데스크탑: 브라우저 설정 각각 분리해서 멘트 수정

---

## ✅ 작업 내용

- [x] 안내 문구 변경

---

## 📷 작업 결과
### 모바일
<img width="362" height="123" alt="image" src="https://github.com/user-attachments/assets/cad7e33c-727b-4ace-8cb2-358355a6d0a4" />

### 데스크탑
<img width="442" height="141" alt="image" src="https://github.com/user-attachments/assets/15335918-72e2-409f-b062-1775c7e63238" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [x] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
