### PR TITLE
style: 병원명이 길어도 모두 표시되도록 수정

### DIFF
--- a/src/pages/home/components/sections/map/fragments/HospitalMapSection.tsx
+++ b/src/pages/home/components/sections/map/fragments/HospitalMapSection.tsx
@@ -222,7 +222,7 @@ const HospitalMapSection = () => {
 
                     <div className="flex min-w-0 flex-1 flex-col justify-between py-1">
                       <div className="flex flex-col gap-y-1.5">
-                        <p className="truncate text-base font-semibold text-gray-950 sm:text-lg">
+                        <p className="text-base font-semibold text-gray-950 sm:text-lg">
                           {hospital.name}
                         </p>
                         <div className="flex flex-wrap gap-x-[5px] gap-y-1">


### PR DESCRIPTION
## 📌 개요

- 병원 정보 카드에 병원명이 길어도 모두 표시될 수 있도록 수정

---

## ✅ 작업 내용

- [x] truncate 지우기

---

## 📷 작업 결과

<img width="321" height="550" alt="image" src="https://github.com/user-attachments/assets/3dd6915a-ffea-49ee-8590-191bf7acb029" />

---

## 🧪 테스트 여부

- [x] 로컬 테스트 완료
- [ ] QA 확인 필요

---

## 🔍 PR 내용 체크사항

- [ ] 리뷰어를 할당 했나요?
- [x] 작업자 할당 했나요?
- [x] 라벨을 추가 했나요?
- [ ] 관련 이슈를 연결 했나요?

---

## 💬 기타

리뷰어에게 전달하고 싶은 말이 있다면 작성해주세요.
